### PR TITLE
Add Meta Pixel base code and ViewContent event to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,6 +685,24 @@
             animation: breathe 4s ease-in-out infinite;
         }
     </style>
+    <!-- Meta Pixel Code -->
+    <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '948697488044593');
+    fbq('track', 'PageView');
+    fbq('track', 'ViewContent');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=948697488044593&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the Meta Pixel (ID: `948697488044593`) to `index.html`.

### Changes
- Inserted the full Meta Pixel base code snippet inside `<head>`, just before `</head>`.
- `fbq('track', 'PageView')` fires from the base pixel as required.
- `fbq('track', 'ViewContent')` is fired immediately after, as the standard event for this landing page.
- A `<noscript>` fallback `<img>` pixel is included for non-JS environments.

### Not changed
- No design, copy, or styling modifications.
- `checkout.html` is untouched.

---

**Note:** These changes have been merged directly into `main` so Netlify will deploy them immediately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a91659-3b7c-4618-98ac-537c522c3011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a91659-3b7c-4618-98ac-537c522c3011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

